### PR TITLE
Upgrade SonarQube to 8.4 & sonar-scala to 8.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sonar-scala-docker
 
-[![GitHub version](<https://img.shields.io/badge/release_(for_SonarQube_8.3.1)-v5.4.0-blue.svg>)](https://github.com/mwz/sonarqube-scala-docker/releases)
+[![GitHub version](<https://img.shields.io/badge/release_(for_SonarQube_8.4.2-v5.5.0-blue.svg>)](https://github.com/mwz/sonarqube-scala-docker/releases)
 [![GitHub version lts](<https://img.shields.io/badge/release_(for_SonarQube_LTS_7.9)-v4.2.0-blue.svg>)](https://github.com/mwz/sonarqube-scala-docker/releases)
 [![GitHub version lts 6.7](<https://img.shields.io/badge/release_(for_SonarQube_LTS_6.7)-v2.12.0-blue.svg>)](https://github.com/mwz/sonarqube-scala-docker/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/mwizner/sonarqube-scala-plugins.svg)](https://hub.docker.com/r/mwizner/sonarqube-scala-plugins)
@@ -8,7 +8,7 @@
 Docker images and docker-compose recipes for out-of-the-box
 [SonarQube 6.7 LTS](https://www.sonarqube.org/sonarqube-6-7-lts),
 [SonarQube 7.9 LTS](https://www.sonarqube.org/sonarqube-7-9-lts) and
-[SonarQube 8.3.1](https://www.sonarqube.org) instance with support
+[SonarQube 8.4.2](https://www.sonarqube.org) instance with support
 for [Scala](http://www.scala-lang.org),
 [Scoverage](https://github.com/scoverage/scalac-scoverage-plugin) (code coverage
 metrics) and [Scalastyle](http://www.scalastyle.org) +
@@ -35,7 +35,7 @@ default SonarQube login details for the Administrator account are `admin:admin`.
 
 You can also use a standalone docker image which contains SonarQube server with
 bundled sonar-scala plugin,
-[`mwizner/sonarqube-scala-plugins:5.4.0-full`](https://hub.docker.com/r/mwizner/sonarqube-scala-plugins)(or
+[`mwizner/sonarqube-scala-plugins:5.5.0-full`](https://hub.docker.com/r/mwizner/sonarqube-scala-plugins)(or
 `mwizner/sonarqube-scala-plugins:latest-full`) and
 [`mwizner/sonarqube-scala-plugins:4.2.0-full`](https://hub.docker.com/r/mwizner/sonarqube-scala-plugins)
 (or `mwizner/sonarqube-scala-plugins:latest-lts-full`) for the current LTS
@@ -54,7 +54,7 @@ docker run -d \
   -e SONARQUBE_JDBC_USERNAME=sonar \
   -e SONARQUBE_JDBC_PASSWORD=sonar \
   -e SONARQUBE_JDBC_URL=jdbc:postgresql://localhost/sonar \
-  mwizner/sonarqube-scala-plugins:5.4.0-full
+  mwizner/sonarqube-scala-plugins:5.5.0-full
 ```
 
 Please note that if you don't specify the `SONARQUBE_JDBC_URL` variable,
@@ -66,14 +66,14 @@ want to try the image, you can use the following command:
 docker run -d \
   --name sonarqube-scala-plugins-full \
   -p 80:9000 \
-  mwizner/sonarqube-scala-plugins:5.4.0-full
+  mwizner/sonarqube-scala-plugins:5.5.0-full
 ```
 
 ## Dependencies
 
 - [SonarQube 6.7 LTS](https://hub.docker.com/_/sonarqube) /
   [SonarQube 7.9 LTS](https://hub.docker.com/_/sonarqube) /
-  [SonarQube 8.3.1](https://hub.docker.com/_/sonarqube)
+  [SonarQube 8.4.2](https://hub.docker.com/_/sonarqube)
 - [PostgreSQL 11](https://hub.docker.com/_/postgres)
 - [mwz/sonar-scala](https://github.com/mwz/sonar-scala) - provides support for
   scalastyle, scoverage and scapegoat
@@ -87,7 +87,7 @@ scapegoat support)_
 <!-- prettier-ignore-start -->
 |Version | SonarQube | sonar-scala |
 |--------|-----------|-------------|
-[5.4.0](https://github.com/mwz/sonarqube-scala-docker/releases/tag/5.4.0) | 8.3.1 [documentation](https://docs.sonarqube.org/8.3), [changelog](https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=15640) | [8.4.0](https://github.com/mwz/sonar-scala/releases/tag/v8.4.0)
+[5.5.0](https://github.com/mwz/sonarqube-scala-docker/releases/tag/5.5.0) | 8.4.2 [documentation](https://docs.sonarqube.org/8.4), [changelog](https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=15833) | [8.5.0](https://github.com/mwz/sonar-scala/releases/tag/v8.5.0)
 [4.2.0](https://github.com/mwz/sonarqube-scala-docker/releases/tag/4.2.0) | 7.9.1 LTS [documentation](https://docs.sonarqube.org/7.9), [changelog](https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=15029) | [7.9.0](https://github.com/mwz/sonar-scala/releases/tag/v7.9.0)
 [2.12.0](https://github.com/mwz/sonarqube-scala-docker/releases/tag/2.12.0) | 6.7.7 LTS [documentation](https://docs.sonarqube.org/display/SONARQUBE67/Documentation), [changelog](https://jira.sonarsource.com/jira/secure/ReleaseNote.jspa?projectId=10930&version=14865) | [6.8.0](https://github.com/mwz/sonar-scala/releases/tag/v6.8.0)
 <!-- prettier-ignore-end -->
@@ -100,6 +100,12 @@ scapegoat support)_
         <td><b>SonarQube</b></td>
         <td><b>sonar-scala</b></td>
         <td><b>sonar-scala-extra</b></td>
+    </tr>
+    <tr>
+        <td><a href="https://github.com/mwz/sonarqube-scala-docker/releases/tag/5.4.0">5.4.0</a></td>
+        <td>8.3.1 <a href="https://docs.sonarqube.org/8.3">documentation</a>, <a href="https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=15640">changelog</a></td>
+        <td><a href="https://github.com/mwz/sonar-scala/releases/tag/v8.4.0">8.4.0</td>
+        <td></td>
     </tr>
     <tr>
         <td><a href="https://github.com/mwz/sonarqube-scala-docker/releases/tag/5.3.0">5.3.0</a></td>
@@ -287,6 +293,7 @@ way to automate analysis of Scala projects with SonarQube.
 <details>
   <summary>Expand to see the changelog.</summary>
   <ul>
+    <li><strong>5.5.0</strong> - Upgraded sonar-scala to 8.5.0 & SonarQube to 8.4.</li>
     <li><strong>5.4.0</strong> - Upgraded sonar-scala to 8.4.0.</li>
     <li><strong>5.3.0</strong> - Upgraded sonar-scala to 8.3.0 & SonarQube to 8.3.</li>
     <li><strong>5.2.0</strong> - Upgraded sonar-scala to 8.2.0 & SonarQube to 8.2.</li>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sonar-scala-docker
 
-[![GitHub version](<https://img.shields.io/badge/release_(for_SonarQube_8.4.2-v5.5.0-blue.svg>)](https://github.com/mwz/sonarqube-scala-docker/releases)
+[![GitHub version](<https://img.shields.io/badge/release_(for_SonarQube_8.4.2)-v5.5.0-blue.svg>)](https://github.com/mwz/sonarqube-scala-docker/releases)
 [![GitHub version lts](<https://img.shields.io/badge/release_(for_SonarQube_LTS_7.9)-v4.2.0-blue.svg>)](https://github.com/mwz/sonarqube-scala-docker/releases)
 [![GitHub version lts 6.7](<https://img.shields.io/badge/release_(for_SonarQube_LTS_6.7)-v2.12.0-blue.svg>)](https://github.com/mwz/sonarqube-scala-docker/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/mwizner/sonarqube-scala-plugins.svg)](https://hub.docker.com/r/mwizner/sonarqube-scala-plugins)
@@ -74,7 +74,7 @@ docker run -d \
 - [SonarQube 6.7 LTS](https://hub.docker.com/_/sonarqube) /
   [SonarQube 7.9 LTS](https://hub.docker.com/_/sonarqube) /
   [SonarQube 8.4.2](https://hub.docker.com/_/sonarqube)
-- [PostgreSQL 11](https://hub.docker.com/_/postgres)
+- [PostgreSQL 12](https://hub.docker.com/_/postgres)
 - [mwz/sonar-scala](https://github.com/mwz/sonar-scala) - provides support for
   scalastyle, scoverage and scapegoat
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -74,7 +74,7 @@ docker run -d \
 - [SonarQube 6.7 LTS](https://hub.docker.com/_/sonarqube) /
   [SonarQube 7.9 LTS](https://hub.docker.com/_/sonarqube) /
   [SonarQube {{current.sonar}}](https://hub.docker.com/_/sonarqube)
-- [PostgreSQL 11](https://hub.docker.com/_/postgres)
+- [PostgreSQL 12](https://hub.docker.com/_/postgres)
 - [mwz/sonar-scala](https://github.com/mwz/sonar-scala) - provides support for
   scalastyle, scoverage and scapegoat
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -135,6 +135,7 @@ way to automate analysis of Scala projects with SonarQube.
 <details>
   <summary>Expand to see the changelog.</summary>
   <ul>
+    <li><strong>5.5.0</strong> - Upgraded sonar-scala to 8.5.0 & SonarQube to 8.4.</li>
     <li><strong>5.4.0</strong> - Upgraded sonar-scala to 8.4.0.</li>
     <li><strong>5.3.0</strong> - Upgraded sonar-scala to 8.3.0 & SonarQube to 8.3.</li>
     <li><strong>5.2.0</strong> - Upgraded sonar-scala to 8.2.0 & SonarQube to 8.2.</li>

--- a/README_DOCKERHUB.md
+++ b/README_DOCKERHUB.md
@@ -1,7 +1,7 @@
 Docker images with out-of-the-box
 [SonarQube 6.7 LTS](https://www.sonarqube.org/sonarqube-6-7-lts),
 [SonarQube 7.9 LTS](https://www.sonarqube.org/sonarqube-7-9-lts) and
-[SonarQube 8.3.1](https://www.sonarqube.org) instance with support
+[SonarQube 8.4.2](https://www.sonarqube.org) instance with support
 for **[Scala](http://www.scala-lang.org)**,
 **[Scoverage](https://github.com/scoverage/scalac-scoverage-plugin)** (code
 coverage metrics) and **[Scalastyle](http://www.scalastyle.org)** +
@@ -18,11 +18,11 @@ Starting from version `2.7.0`, the images no longer contain the
 [sonar-scala-extra](https://github.com/arthepsy/sonar-scala-extra) plugin as
 sonar-scala provides Scapegoat support from version `6.5.0` onwards.
 
-- `5.4.0`, `latest`
-  [Dockerfile](https://github.com/mwz/sonar-scala-docker/blob/master/5.4.0/Dockerfile),
-  `5.4.0-full`, `latest-full`
-  [Dockerfile](https://github.com/mwz/sonar-scala-docker/blob/master/5.4.0-full/Dockerfile),
-  [Release 5.4.0](https://github.com/mwz/sonar-scala-docker/releases/tag/5.4.0)
+- `5.5.0`, `latest`
+  [Dockerfile](https://github.com/mwz/sonar-scala-docker/blob/master/5.5.0/Dockerfile),
+  `5.5.0-full`, `latest-full`
+  [Dockerfile](https://github.com/mwz/sonar-scala-docker/blob/master/5.5.0-full/Dockerfile),
+  [Release 5.5.0](https://github.com/mwz/sonar-scala-docker/releases/tag/5.5.0)
 - `4.2.0`, `latest-lts` (7.9 LTS)
   [Dockerfile](https://github.com/mwz/sonar-scala-docker/blob/master/4.2.0/Dockerfile),
   `4.2.0-full`, `latest-lts-full` (7.9 LTS)
@@ -41,8 +41,8 @@ For older versions please check the
 
 | Version                  | SonarQube         | sonar-scala            |
 | ------------------------ | ----------------- | ---------------------- |
-| 5.4.0      |                   | 8.4.0 |
-| 5.4.0-full | 8.3.1 | 8.4.0 |
+| 5.5.0      |                   | 8.5.0 |
+| 5.5.0-full | 8.4.2 | 8.5.0 |
 | 4.2.0          |                   | 7.9.0     |
 | 4.2.0-full     | 7.9.1 LTS     | 7.9.0     |
 | 2.12.0        |                   | 6.8.0   |
@@ -58,7 +58,7 @@ version: "2"
 
 services:
   sonarqube:
-    image: sonarqube:8.3.1-community
+    image: sonarqube:8.4.2-community
     ports:
       - "80:9000"
     networks:
@@ -67,7 +67,7 @@ services:
       - plugins
 
   plugins:
-    image: mwizner/sonarqube-scala-plugins:5.4.0
+    image: mwizner/sonarqube-scala-plugins:5.5.0
     volumes:
       - sonarqube_plugins:/opt/sonarqube/extensions/plugins
     command: /bin/true
@@ -95,7 +95,7 @@ docker run -d \
   -e SONARQUBE_JDBC_USERNAME=sonar \
   -e SONARQUBE_JDBC_PASSWORD=sonar \
   -e SONARQUBE_JDBC_URL=jdbc:postgresql://localhost/sonar \
-  mwizner/sonarqube-scala-plugins:5.4.0-full
+  mwizner/sonarqube-scala-plugins:5.5.0-full
 ```
 
 Please note that if you don't specify the `SONARQUBE_JDBC_URL` variable,
@@ -107,7 +107,7 @@ want to try the image, you can use the following command:
 docker run -d \
   --name sonarqube-scala-plugins-full \
   -p 80:9000 \
-  mwizner/sonarqube-scala-plugins:5.4.0-full
+  mwizner/sonarqube-scala-plugins:5.5.0-full
 ```
 
 ## Repository

--- a/conf/sonar.properties
+++ b/conf/sonar.properties
@@ -22,7 +22,6 @@
 # H2 embedded database server listening port, defaults to 9092
 #sonar.embeddedDatabase.port=9092
 
-
 #----- Oracle 11g/12c/18c/19c
 # The Oracle JDBC driver must be copied into the directory extensions/jdbc-driver/oracle/.
 # Only the thin client is supported, and we recommend using the latest Oracle JDBC driver. See
@@ -30,11 +29,9 @@
 # If you need to set the schema, please refer to http://jira.sonarsource.com/browse/SONAR-5000
 #sonar.jdbc.url=jdbc:oracle:thin:@localhost:1521/XE
 
-
 #----- PostgreSQL 9.3 or greater
 # By default the schema named "public" is used. It can be overridden with the parameter "currentSchema".
 #sonar.jdbc.url=jdbc:postgresql://localhost/sonarqube?currentSchema=my_schema
-
 
 #----- Microsoft SQLServer 2014/2016/2017 and SQL Azure
 # A database named sonar must exist and its collation must be case-sensitive (CS) and accent-sensitive (AS)
@@ -49,7 +46,6 @@
 # Use the following connection string if you want to use SQL Auth while connecting to MS Sql Server.
 # Set the sonar.jdbc.username and sonar.jdbc.password appropriately.
 #sonar.jdbc.url=jdbc:sqlserver://localhost;databaseName=sonar
-
 
 #----- Connection pool settings
 # The maximum number of active connections that can be allocated
@@ -74,8 +70,6 @@
 
 #sonar.jdbc.minEvictableIdleTimeMillis=600000
 #sonar.jdbc.timeBetweenEvictionRunsMillis=30000
-
-
 
 #--------------------------------------------------------------------------------------------------
 # WEB SERVER
@@ -107,7 +101,6 @@
 # TCP port for incoming HTTP connections. Default value is 9000.
 #sonar.web.port=9000
 
-
 # The maximum number of connections that the server will accept and process at any given time.
 # When this number has been reached, the server will not accept any more connections until
 # the number of connections falls below this value. The operating system may still accept connections
@@ -131,8 +124,9 @@
 
 # The inactivity timeout duration of user sessions, in minutes. After the configured
 # period of time, the user is logged out.
-# The default value is set to 3 days (4320 minutes)
-# and cannot be greater than 3 months. Value must be strictly positive.
+# The default value is set to 3 days (4320 minutes).
+# It must be set between 5 minutes and 3 months.
+# Value must be strictly positive.
 #sonar.web.sessionTimeoutInMinutes=4320
 
 # A passcode can be defined to access some web services from monitoring
@@ -141,7 +135,6 @@
 # The passcode should be provided in HTTP requests with the header "X-Sonar-Passcode".
 # By default feature is disabled.
 #sonar.web.systemPasscode=
-
 
 #--------------------------------------------------------------------------------------------------
 # SSO AUTHENTICATION
@@ -246,7 +239,6 @@
 # Same as previous property, but allows to not repeat all other settings like -Xmx
 #sonar.ce.javaAdditionalOpts=
 
-
 #--------------------------------------------------------------------------------------------------
 # ELASTICSEARCH
 # Elasticsearch is used to facilitate fast and accurate information retrieval.
@@ -278,7 +270,6 @@
 # As a security precaution, should NOT be set to a publicly available address.
 #sonar.search.host=
 
-
 #--------------------------------------------------------------------------------------------------
 # UPDATE CENTER
 
@@ -309,7 +300,6 @@
 #                   used for HTTP and HTTPS (default none)
 #                   (note: localhost and its literal notations (127.0.0.1, ...) are always excluded)
 #http.nonProxyHosts=
-
 
 #--------------------------------------------------------------------------------------------------
 # LOGGING
@@ -393,7 +383,6 @@
 # Default value (which was "combined" before version 6.2) is equivalent to "combined + SQ HTTP request ID":
 #sonar.web.accessLogs.pattern=%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" "%reqAttribute{ID}"
 
-
 #--------------------------------------------------------------------------------------------------
 # OTHERS
 
@@ -411,7 +400,6 @@
 # We don't collect source code or IP addresses. And we don't share the data with anyone else.
 # To see an example of the data shared: login as a global administrator, call the WS api/system/info and check the Statistics field.
 sonar.telemetry.enable=false
-
 
 #--------------------------------------------------------------------------------------------------
 # DEVELOPMENT - only for developers

--- a/current/Dockerfile
+++ b/current/Dockerfile
@@ -4,8 +4,8 @@
 FROM bitnami/minideb:stretch
 RUN install_packages curl ca-certificates
 
-ENV SONAR_SCALA_VERSION 8.4.0
-ENV GIT_PLUGIN_VERSION 1.11.1.2008
+ENV SONAR_SCALA_VERSION 8.5.0
+ENV GIT_PLUGIN_VERSION 1.12.0.2034
 ENV SQ_EXTENSIONS_DIR "/opt/sonarqube/extensions"
 
 RUN groupadd -g 1000 -r sonarqube && useradd -r -g sonarqube sonarqube

--- a/current/Dockerfile
+++ b/current/Dockerfile
@@ -5,7 +5,7 @@ FROM bitnami/minideb:stretch
 RUN install_packages curl ca-certificates
 
 ENV SONAR_SCALA_VERSION 8.5.0
-ENV GIT_PLUGIN_VERSION 1.12.0.2034
+ENV GIT_PLUGIN_VERSION 1.11.1.2008
 ENV SQ_EXTENSIONS_DIR "/opt/sonarqube/extensions"
 
 RUN groupadd -g 1000 -r sonarqube && useradd -r -g sonarqube sonarqube

--- a/current/full/Dockerfile
+++ b/current/full/Dockerfile
@@ -1,8 +1,8 @@
-# SonarQube 8.3 image with bundled sonar-scala (https://github.com/mwz/sonar-scala).
+# SonarQube 8.4 image with bundled sonar-scala (https://github.com/mwz/sonar-scala).
 
-FROM sonarqube:8.3.1-community
+FROM sonarqube:8.4.2-community
 
-ENV SONAR_SCALA_VERSION 8.4.0
+ENV SONAR_SCALA_VERSION 8.5.0
 
 RUN rm $SQ_EXTENSIONS_DIR/plugins/sonar-scala-plugin-* && \
   wget -O "${SQ_EXTENSIONS_DIR}/plugins/sonar-scala-plugin-${SONAR_SCALA_VERSION}.jar" \

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-export SONAR_SCALA_VERSION=8.4.0-SNAPSHOT
+export SONAR_SCALA_VERSION=8.5.0-SNAPSHOT
 cp ~/.ivy2/local/com.github.mwz/sonar-scala_2.13/${SONAR_SCALA_VERSION}/jars/sonar-scala_2.13-assembly.jar .
 docker build -t mwizner/sonarqube-scala-plugins:dev --build-arg SONAR_SCALA_VERSION=${SONAR_SCALA_VERSION} .

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-export SONAR_SCALA_VERSION=8.5.0-SNAPSHOT
+export SONAR_SCALA_VERSION=8.6.0-SNAPSHOT
 cp ~/.ivy2/local/com.github.mwz/sonar-scala_2.13/${SONAR_SCALA_VERSION}/jars/sonar-scala_2.13-assembly.jar .
 docker build -t mwizner/sonarqube-scala-plugins:dev --build-arg SONAR_SCALA_VERSION=${SONAR_SCALA_VERSION} .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   sonarqube:
-    image: sonarqube:8.3.1-community
+    image: sonarqube:8.4.2-community
     ports:
       - "80:9000"
     networks:
@@ -21,7 +21,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:11.7-alpine
+    image: postgres:12.4-alpine
     networks:
       - sonarnet
     environment:

--- a/vars.json
+++ b/vars.json
@@ -1,10 +1,10 @@
 {
   "current": {
-    "version": "5.4.0",
-    "sonar": "8.3.1",
-    "sonarDocs": "https://docs.sonarqube.org/8.3",
-    "sonarChangelog": "https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=15640",
-    "sonarScala": "8.4.0"
+    "version": "5.5.0",
+    "sonar": "8.4.2",
+    "sonarDocs": "https://docs.sonarqube.org/8.4",
+    "sonarChangelog": "https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=15833",
+    "sonarScala": "8.5.0"
   },
   "lts": {
     "version": "4.2.0",
@@ -22,6 +22,13 @@
   },
   "versions": {
     "current": [
+      {
+        "version": "5.4.0",
+        "sonar": "8.3.1",
+        "sonarDocs": "https://docs.sonarqube.org/8.3",
+        "sonarChangelog": "https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10930&version=15640",
+        "sonarScala": "8.4.0"
+      },
       {
         "version": "5.3.0",
         "sonar": "8.3.1",


### PR DESCRIPTION
Closes #27 

DO NOT merge until [this PR](https://github.com/mwz/sonar-scala/pull/515) has been merged and sonar-scala 8.5.0 has been released